### PR TITLE
Fixed broken links in docs

### DIFF
--- a/docs/connectors/data_consumer_guide.md
+++ b/docs/connectors/data_consumer_guide.md
@@ -2,12 +2,10 @@
 
 ## Understanding data types
 
-
 The Code Climate Data Engineering Platform has a standard Data Schema,
 representing 50+ common software development units, like epics, pull requests,
 builds, incidents and more. Get a overview of the different data types
 on the [Schema reference](docs/schemas/README.md).
-
 
 ## Invoking a connector on the CLI
 
@@ -15,7 +13,7 @@ For example, you're interested on using the CLI with the PagerDuty
 connector. You can run the following commands to verify, discover
 and sync:
 
-```
+```bash
 # Verify
 yarn run \
   codeclimate-connector verify-configuration \

--- a/docs/connectors/getting_started.md
+++ b/docs/connectors/getting_started.md
@@ -1,32 +1,34 @@
 # Getting Started
 
 ## Using a Connector
-Follow the [Data Consumer’s Guide](docs/connectors/data_consumer_guide.md)
+
+Follow the [Data Consumer’s Guide](./data_consumer_guide.md)
 to learn how to use a Code Climate Connector. An easy-to-follow introduction
 to understanding data types, running a connector through the CLI and following
 the state of a connector.
 
 ## Concepts
-Learn the [Concepts](docs/connectors/concepts.md) of Code Climate Connectors by
+
+Learn the [Concepts](./concepts.md) of Code Climate Connectors by
 reviewing its components and operations.
 
 ## Building a Connector
 
 Learn how to integrate with a data source by following
-a [Connector Developer’s Guide](docs/connectors/connector_developer_guide.md).
+a [Connector Developer’s Guide](./connector_developer_guide.md).
 This tutorial will cover a step-by-step guide on implementing the connector
 and how to publish it.
 
 ## Reference
 
 For a detailed overview of the Data Schema Connectors Specification,
-check out the [Reference](docs/connecotrs/reference.md).
+check out the [Reference](./reference.md).
 
 ## Reference implementations
 
-- PagerDuty: https://github.com/codeclimate/codeclimate-connector-pagerduty
-- CodeCov https://github.com/codeclimate/codeclimate-connector-codecov
-- CircleCI https://github.com/codeclimate/codeclimate-connector-circleci
+- [PagerDuty](https://github.com/codeclimate/codeclimate-connector-pagerduty)
+- [CodeCov](https://github.com/codeclimate/codeclimate-connector-codecov)
+- [CircleCI](https://github.com/codeclimate/codeclimate-connector-circleci)
 
 ## Community and Support
 
@@ -36,5 +38,5 @@ with the core team and contributing to the project:
 
 * [Join the conversation on Slack](https://slack.codeclimate.com/) with
 hundreds of community contributors
-* Subscribe to our Developer Program mailing list (https://codeclimate.com/dev_form/)
+* Subscribe to our [Developer Program mailing list](https://codeclimate.com/dev_form/)
 to stay up-to-date


### PR DESCRIPTION
Fixed a few broken links I noticed in the docs.  Also, updated the list of connectors to use hyperlinks vs. display the full URL.  Let me know if ya'll prefer the original.   Happy to revert those changes.