### PR TITLE
Deprecate other_locations in analyzer spec, to clarify vs. trace

### DIFF
--- a/spec/analyzers/SPEC.md
+++ b/spec/analyzers/SPEC.md
@@ -153,6 +153,7 @@ An `issue` represents a single instance of a real or potential code problem, det
   "categories": ["Complexity"],
   "location": Location,
   "other_locations": [Location],
+  "trace": Trace,
   "remediation_points": 50000,
   "severity": Severity,
   "fingerprint": "abcd1234"
@@ -165,6 +166,7 @@ An `issue` represents a single instance of a real or potential code problem, det
 * `content` -- **Optional**. A markdown snippet describing the issue, including deeper explanations and links to other resources.
 * `categories` -- **Required**. At least one category indicating the nature of the issue being reported.
 * `location` -- **Required**. A `Location` object representing the place in the source code where the issue was discovered.
+* `other_locations` -- **Optional, deprecated.** Use `trace` instead.
 * `trace` -- **Optional.** A `Trace` object representing other interesting source code locations related to this issue.
 * `remediation_points` -- **Optional**. An integer indicating a rough estimate of how long it would take to resolve the reported issue.
 * `severity` -- **Optional**. A `Severity` string (`info`, `minor`, `major`, `critical`, or `blocker`) describing the potential impact of the issue found.
@@ -267,23 +269,6 @@ line of the file.
 
 Offsets, however are 0-based. A Position of `{ "offset": 4 }` represents the _fifth_ character in the file. Importantly, the `offset` is from the beginning of the file, not the beginning of a line. Newline characters (and all characters) count when computing an offset.
 
-### Other Locations
-
-Other locations is an optional array of [Location](#locations) objects:
-
-```json
-"other_locations": [
-  {
-    "path": "foo.rb",
-    "lines": { "begin": 25, "end": 55 }
-  },
-  {
-    "path": "bar.rb",
-    "lines": { "begin": 20, "end": 50 }
-  }
-]
-```
-
 ### Contents
 
 Content gives more information about the issue's check, including a description of the issue, how to fix it, and relevant links. They are expressed as a hash with a `body` key. The value of this key should be a [Markdown](http://daringfireball.net/projects/markdown/) document. For example:
@@ -320,7 +305,6 @@ An example trace:
     }],
   "stacktrace": true
 }
-
 ```
 
 

--- a/spec/analyzers/SPEC.md
+++ b/spec/analyzers/SPEC.md
@@ -165,7 +165,7 @@ An `issue` represents a single instance of a real or potential code problem, det
 * `content` -- **Optional**. A markdown snippet describing the issue, including deeper explanations and links to other resources.
 * `categories` -- **Required**. At least one category indicating the nature of the issue being reported.
 * `location` -- **Required**. A `Location` object representing the place in the source code where the issue was discovered.
-* `other_locations` -- **Optional, deprecated.** Use `trace` instead.
+* `other_locations` -- **Optional, deprecated.** _Use `trace` instead._ Other locations is an optional array of [`Location`](#locations) objects.
 * `trace` -- **Optional.** A `Trace` object representing other interesting source code locations related to this issue.
 * `remediation_points` -- **Optional**. An integer indicating a rough estimate of how long it would take to resolve the reported issue.
 * `severity` -- **Optional**. A `Severity` string (`info`, `minor`, `major`, `critical`, or `blocker`) describing the potential impact of the issue found.

--- a/spec/analyzers/SPEC.md
+++ b/spec/analyzers/SPEC.md
@@ -29,7 +29,6 @@ We welcome your participation and appreciate your patience as we finalize the pl
         - [Remediation points](#remediation-points)
     - [Locations](#locations)
         - [Positions](#positions)
-    - [Other Locations](#other-locations)
     - [Contents](#contents)
     - [Source code traces](#source-code-traces)
 - [Packaging](#packaging)


### PR DESCRIPTION
It appears that #20 intended to remove `other_locations` as superseded by `trace`, but it left the old entry (only) in the example JSON object. An expanded section describing `other_locations` was put back in #57, that issue thread asserts that it is still valid and in use by Code Climate's duplication engine.

These two fields certainly seem functionally redundant, hence the confusion in #56, which I shared too.

Under assumption that both are used/accepted in implementations of the current version of the spec, this change restores presence of both in the reference but proposes deprecating `other_locations` and hence de-emphasizes its documentation (`Trace` objects are already specified in detail).

The spec version was 0.3.1 as of #57, and still is now.